### PR TITLE
Refactor promises to use `Q.Promise` instead of `Q.defer`

### DIFF
--- a/ch14/handlers/cart.js
+++ b/ch14/handlers/cart.js
@@ -16,14 +16,13 @@ exports.middleware = function(req, res, next){
 			};
 		})
 	};
-	var promises = [];
-	req.cart.items.forEach(function(item){
-		var d = Q.defer();
-		promises.push(d.promise);
-		Vacation.findOne({ sku: item.sku }, function(err, vacation){
-			if(err) return d.reject(err);
-			item.vacation = vacation;
-			d.resolve();
+	var promises = req.cart.items.map(function(item){
+		return Q.Promise(function(resolve, reject){
+			Vacation.findOne({ sku: item.sku }, function(err, vacation){
+				if(err) return reject(err);
+				item.vacation = vacation;
+				resolve();
+			});
 		});
 	});
 	Q.all(promises)

--- a/ch15/handlers/cart.js
+++ b/ch15/handlers/cart.js
@@ -16,14 +16,13 @@ exports.middleware = function(req, res, next){
 			};
 		})
 	};
-	var promises = [];
-	req.cart.items.forEach(function(item){
-		var d = Q.defer();
-		promises.push(d.promise);
-		Vacation.findOne({ sku: item.sku }, function(err, vacation){
-			if(err) return d.reject(err);
-			item.vacation = vacation;
-			d.resolve();
+	var promises = req.cart.items.map(function(item){
+		return Q.Promise(function(resolve, reject){
+			Vacation.findOne({ sku: item.sku }, function(err, vacation){
+				if(err) return reject(err);
+				item.vacation = vacation;
+				resolve();
+			});
 		});
 	});
 	Q.all(promises)

--- a/ch16/handlers/cart.js
+++ b/ch16/handlers/cart.js
@@ -16,14 +16,13 @@ exports.middleware = function(req, res, next){
 			};
 		})
 	};
-	var promises = [];
-	req.cart.items.forEach(function(item){
-		var d = Q.defer();
-		promises.push(d.promise);
-		Vacation.findOne({ sku: item.sku }, function(err, vacation){
-			if(err) return d.reject(err);
-			item.vacation = vacation;
-			d.resolve();
+	var promises = req.cart.items.map(function(item){
+		return Q.Promise(function(resolve, reject){
+			Vacation.findOne({ sku: item.sku }, function(err, vacation){
+				if(err) return reject(err);
+				item.vacation = vacation;
+				resolve();
+			});
 		});
 	});
 	Q.all(promises)

--- a/ch17/handlers/cart.js
+++ b/ch17/handlers/cart.js
@@ -16,14 +16,13 @@ exports.middleware = function(req, res, next){
 			};
 		})
 	};
-	var promises = [];
-	req.cart.items.forEach(function(item){
-		var d = Q.defer();
-		promises.push(d.promise);
-		Vacation.findOne({ sku: item.sku }, function(err, vacation){
-			if(err) return d.reject(err);
-			item.vacation = vacation;
-			d.resolve();
+	var promises = req.cart.items.map(function(item){
+		return Q.Promise(function(resolve, reject){
+			Vacation.findOne({ sku: item.sku }, function(err, vacation){
+				if(err) return reject(err);
+				item.vacation = vacation;
+				resolve();
+			});
 		});
 	});
 	Q.all(promises)

--- a/ch18/handlers/cart.js
+++ b/ch18/handlers/cart.js
@@ -16,14 +16,13 @@ exports.middleware = function(req, res, next){
 			};
 		})
 	};
-	var promises = [];
-	req.cart.items.forEach(function(item){
-		var d = Q.defer();
-		promises.push(d.promise);
-		Vacation.findOne({ sku: item.sku }, function(err, vacation){
-			if(err) return d.reject(err);
-			item.vacation = vacation;
-			d.resolve();
+	var promises = req.cart.items.map(function(item){
+		return Q.Promise(function(resolve, reject){
+			Vacation.findOne({ sku: item.sku }, function(err, vacation){
+				if(err) return reject(err);
+				item.vacation = vacation;
+				resolve();
+			});
 		});
 	});
 	Q.all(promises)

--- a/ch19/handlers/cart.js
+++ b/ch19/handlers/cart.js
@@ -16,14 +16,13 @@ exports.middleware = function(req, res, next){
 			};
 		})
 	};
-	var promises = [];
-	req.cart.items.forEach(function(item){
-		var d = Q.defer();
-		promises.push(d.promise);
-		Vacation.findOne({ sku: item.sku }, function(err, vacation){
-			if(err) return d.reject(err);
-			item.vacation = vacation;
-			d.resolve();
+	var promises = req.cart.items.map(function(item){
+		return Q.Promise(function(resolve, reject){
+			Vacation.findOne({ sku: item.sku }, function(err, vacation){
+				if(err) return reject(err);
+				item.vacation = vacation;
+				resolve();
+			});
 		});
 	});
 	Q.all(promises)

--- a/ch19/meadowlark.js
+++ b/ch19/meadowlark.js
@@ -372,27 +372,26 @@ var getWeatherData = (function(){
     return function() {
         if( !c.refreshing && Date.now() > c.refreshed + c.updateFrequency ){
             c.refreshing = true;
-            var promises = [];
-            c.locations.forEach(function(loc){
-                var deferred = Q.defer();
-                var url = 'http://api.wunderground.com/api/' +
-                    credentials.WeatherUnderground.ApiKey +
-                    '/conditions/q/OR/' + loc.name + '.json';
-                http.get(url, function(res){
-                    var body = '';
-                    res.on('data', function(chunk){
-                        body += chunk;
-                    });
-                    res.on('end', function(){
-                        body = JSON.parse(body);
-                        loc.forecastUrl = body.current_observation.forecast_url;
-                        loc.iconUrl = body.current_observation.icon_url;
-                        loc.weather = body.current_observation.weather;
-                        loc.temp = body.current_observation.temperature_string;
-                        deferred.resolve();
+            var promises = c.locations.map(function(loc){
+                return Q.Promise(function(resolve){
+                    var url = 'http://api.wunderground.com/api/' +
+                        credentials.WeatherUnderground.ApiKey +
+                        '/conditions/q/OR/' + loc.name + '.json';
+                    http.get(url, function(res){
+                        var body = '';
+                        res.on('data', function(chunk){
+                            body += chunk;
+                        });
+                        res.on('end', function(){
+                            body = JSON.parse(body);
+                            loc.forecastUrl = body.current_observation.forecast_url;
+                            loc.iconUrl = body.current_observation.icon_url;
+                            loc.weather = body.current_observation.weather;
+                            loc.temp = body.current_observation.temperature_string;
+                            resolve();
+                        });
                     });
                 });
-                promises.push(deferred);
             });
             Q.all(promises).then(function(){
                 c.refreshing = false;
@@ -425,15 +424,14 @@ function getTopTweets(cb){
 
 	twitter.search('#travel', topTweets.count, function(result){
 		var formattedTweets = [];
-		var promises = [];
 		var embedOpts = { omit_script: 1 };
-		result.statuses.forEach(function(status){
-			var deferred = Q.defer();
-			twitter.embed(status.id_str, embedOpts, function(embed){
-				formattedTweets.push(embed.html);
-				deferred.resolve();
-			});
-			promises.push(deferred.promise);
+		var promises = result.statuses.map(function(status){
+            return Q.Promise(function(resolve){
+    			twitter.embed(status.id_str, embedOpts, function(embed){
+    				formattedTweets.push(embed.html);
+    				resolve();
+    			});
+            });
 		});
 		Q.all(promises).then(function(){
 			topTweets.lastRefreshed = Date.now();


### PR DESCRIPTION
Since promises are now a part of ES2015 it’s better to use the [revealing constructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/) that more resembles the spec than the “deferred pattern” when creating promises.

Reference: http://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html