### PR TITLE
Change `getTopTweets()` function to always be async

### DIFF
--- a/ch19/meadowlark.js
+++ b/ch19/meadowlark.js
@@ -420,8 +420,11 @@ var topTweets = {
 	tweets: [],
 };
 function getTopTweets(cb){
-	if(Date.now() < topTweets.lastRefreshed + topTweets.refreshInterval)
-		return cb(topTweets.tweets);
+	if(Date.now() < topTweets.lastRefreshed + topTweets.refreshInterval) {
+		return setImmediate(function() {
+            cb(topTweets.tweets);
+        });
+    }
 
 	twitter.search('#travel', topTweets.count, function(result){
 		var formattedTweets = [];


### PR DESCRIPTION
It’s an anti-pattern to have a function sometimes invoke it’s callback synchronously and sometimes asynchronously

Reference: http://blog.ometer.com/2011/07/24/callbacks-synchronous-and-asynchronous